### PR TITLE
fix: Readme logo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-![axiom-ai: The official package to send events from AI libraries to Axiom](https://user-images.githubusercontent.com/163243/229035544-e4f5a8b2-eb65-4ef0-a17f-393072dc84c5.svg#gh-dark-mode-only)
-![axiom-ai: The official package to send events from AI libraries to Axiom](https://user-images.githubusercontent.com/163243/229035583-e97a467c-6f80-4826-8424-2337bd0f66b7.svg#gh-light-mode-only)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/163243/229035544-e4f5a8b2-eb65-4ef0-a17f-393072dc84c5.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/163243/229035583-e97a467c-6f80-4826-8424-2337bd0f66b7.svg">
+  <img alt="axiom-ai: The official package to send events from AI libraries to Axiom" src="https://user-images.githubusercontent.com/163243/229035583-e97a467c-6f80-4826-8424-2337bd0f66b7.svg">
+</picture>
 
 [Axiom](https://axiom.co) unlocks observability at any scale.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![axiom-ai: The official package to send events from AI libraries to Axiom](.github/images/banner-dark.svg#gh-dark-mode-only)
-![axiom-ai: The official package to send events from AI libraries to Axiom](.github/images/banner-light.svg#gh-light-mode-only)
+![axiom-ai: The official package to send events from AI libraries to Axiom](https://user-images.githubusercontent.com/163243/229035544-e4f5a8b2-eb65-4ef0-a17f-393072dc84c5.svg#gh-dark-mode-only)
+![axiom-ai: The official package to send events from AI libraries to Axiom](https://user-images.githubusercontent.com/163243/229035583-e97a467c-6f80-4826-8424-2337bd0f66b7.svg#gh-light-mode-only)
 
 [Axiom](https://axiom.co) unlocks observability at any scale.
 


### PR DESCRIPTION
use the [preferred picture method](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to) for light/dark images in the readme, also uploaded the svgs to github cdn so they work on other sites (like npmjs.com)

avoiding this:
![Screenshot 2023-03-31 at 01 28 25](https://user-images.githubusercontent.com/163243/229041727-7baca209-a88a-4c1f-837d-6cde680114bb.png)
