### PR TITLE
Add batching

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,18 @@ import { withAxiom } from "axiom-ai/openai";
   const configuration = new Configuration({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  const openai = withAxiom(new OpenAIApi(configuration), {
+  const { openai, flush } = withAxiom(new OpenAIApi(configuration), {
     token: process.env.AXIOM_TOKEN,
     dataset: process.env.AXIOM_DATASET,
+    // excludePromptOrMessages: false,
+    // excludeChoices: false,
+    // sendType: "batch", // or "immediate" for sending events synchronously
+  });
+
+  // We need to flush events before exit
+  process.on("beforeExit", async () => {
+    await flush()
+    process.exit(0);
   });
 
   const completion = await openai.createCompletion({
@@ -77,7 +86,3 @@ This is what an event could look like.
   "type": "completion"
 }
 ```
-
-If you pass `excludePromptOrMessages: true` and/or `excludeChoices: true` to 
-the `withAxiom` options it won't send the prompt/messages or choices, 
-respectively.

--- a/examples/openai-basic.ts
+++ b/examples/openai-basic.ts
@@ -8,7 +8,11 @@ import { withAxiom } from "axiom-ai/openai";
   const configuration = new Configuration({
     apiKey: process.env.OPENAI_API_KEY,
   });
-  const openai = withAxiom(new OpenAIApi(configuration));
+  const { openai, flush } = withAxiom(new OpenAIApi(configuration));
+  process.on("beforeExit", async () => {
+    await flush()
+    process.exit(0);
+  });
 
   const completion = await openai.createCompletion({
     model: "text-davinci-003",

--- a/examples/openai-immediate.ts
+++ b/examples/openai-immediate.ts
@@ -1,0 +1,18 @@
+import * as dotenv from 'dotenv';
+import { Configuration, OpenAIApi } from "openai";
+import { withAxiom } from "axiom-ai/openai";
+
+(async function() {
+  dotenv.config()
+
+  const configuration = new Configuration({
+    apiKey: process.env.OPENAI_API_KEY,
+  });
+  const { openai } = withAxiom(new OpenAIApi(configuration), { sendType: "immediate" });
+
+  const completion = await openai.createCompletion({
+    model: "text-davinci-003",
+    prompt: "Hello world",
+  });
+  console.log(completion.data.choices[0].text);
+})()

--- a/openai.ts
+++ b/openai.ts
@@ -1,17 +1,24 @@
 import { OpenAIApi, CreateCompletionRequest, CreateChatCompletionRequest } from "openai";
 import { AxiosRequestConfig } from "axios";
-import BatchedAxiomClient from './shared';
+import { AxiomClient, BatchedAxiomClient, ImmediateAxiomClient } from './shared';
 
 export interface WithAxiomOptions {
   token?: string;
   dataset?: string;
   excludePromptOrMessages?: boolean;
   excludeChoices?: boolean;
+  sendType?: "batch"|"immediate";
 }
 
 export function withAxiom(openai: OpenAIApi, opts?: WithAxiomOptions): { openai: OpenAIApi, flush: Function } {
   const dataset = opts?.dataset || process.env.AXIOM_DATASET;
-  const axiom = new BatchedAxiomClient(opts?.token, dataset!);
+
+  let axiom: AxiomClient;
+  if (opts?.sendType === "immediate") {
+    axiom = new ImmediateAxiomClient(opts?.token, dataset!);
+  } else {
+    axiom = new BatchedAxiomClient(opts?.token, dataset!);
+  }
 
   const createCompletion = openai.createCompletion;
   openai.createCompletion = async (request: CreateCompletionRequest, options?: AxiosRequestConfig<any>) => {

--- a/shared.ts
+++ b/shared.ts
@@ -1,0 +1,67 @@
+import Client from "@axiomhq/axiom-node";
+
+function throttle(fn: Function, wait: number) {
+  let lastFn: ReturnType<typeof setTimeout>, lastTime: number;
+  return function (this: any) {
+    const context = this,
+      args = arguments;
+
+    // First call, set lastTime
+    if (lastTime == null) {
+      lastTime = Date.now();
+    }
+
+    clearTimeout(lastFn);
+    lastFn = setTimeout(() => {
+      if (Date.now() - lastTime >= wait) {
+        fn.apply(context, args);
+        lastTime = Date.now();
+      }
+    }, Math.max(wait - (Date.now() - lastTime), 0));
+  };
+}
+
+const FLUSH_INTERVAL = 1000;
+const FLUSH_SIZE = 1000;
+
+export default class BatchedAxiomClient {
+  private readonly client: Client;
+  private readonly dataset: string;
+  private batch: object[];
+  private throttledFlush = throttle(this.flush.bind(this), FLUSH_INTERVAL);
+  private activeFlush: Promise<void> | null = null;
+
+  constructor(token: string | undefined, dataset: string) {
+    this.client = new Client({ token });
+    this.dataset = dataset;
+    this.batch = [];
+  }
+
+  // Ingests events into Axiom asynchronously every FLUSH_SIZE events or 
+  // FLUSH_INTERVAL millis
+  public async ingestEvents(events: Array<object> | object) {
+    if (!Array.isArray(events)) {
+      this.batch.push(events);
+    } else {
+      this.batch.push(...events);
+    }
+
+    if (this.batch.length >= FLUSH_SIZE) {
+      this.flush();
+    } else {
+      this.throttledFlush();
+    }
+  }
+
+  public async flush() {
+    // If there's an active flush (due to throttling), wait for it to finish first
+    if (this.activeFlush) {
+      await this.activeFlush;
+    }
+
+    this.activeFlush = (async () => {
+      await this.client.ingestEvents(this.dataset, this.batch);
+      this.batch = [];
+    })()
+  }
+}

--- a/shared.ts
+++ b/shared.ts
@@ -21,10 +21,33 @@ function throttle(fn: Function, wait: number) {
   };
 }
 
+export interface AxiomClient {
+  ingestEvents(events: Array<object> | object): Promise<void>
+  flush(): Promise<void>
+}
+
+export class ImmediateAxiomClient implements AxiomClient {
+  private readonly client: Client;
+  private readonly dataset: string;
+
+  constructor(token: string | undefined, dataset: string) {
+    this.client = new Client({ token });
+    this.dataset = dataset;
+  }
+
+  public async ingestEvents(events: Array<object> | object) {
+    await this.client.ingestEvents(this.dataset, events);
+  }
+
+  public async flush() {
+    // No-op
+  }
+}
+
 const FLUSH_INTERVAL = 1000;
 const FLUSH_SIZE = 1000;
 
-export default class BatchedAxiomClient {
+export class BatchedAxiomClient implements AxiomClient {
   private readonly client: Client;
   private readonly dataset: string;
   private batch: object[];


### PR DESCRIPTION
This adds a batching client, introducing the need to call `flush()` before exit.

It also adds a `sendType` option that defaults to `batch` but can be set to `immediate` to send events synchronously.